### PR TITLE
Fix ->assert_ok for negative statuses

### DIFF
--- a/lib/Process/Status.pm
+++ b/lib/Process/Status.pm
@@ -189,6 +189,12 @@ sub assert_ok {
   sub as_string {
     qq{did not run; \$? was $_[0][0], \$! was "$_[0][1]" (errno $_[0][2])}
   }
+
+  sub assert_ok {
+    require Carp;
+    my $name = @_ > 1 ? $_[1] : "program";
+    Carp::croak("$name " . $_[0]->as_string);
+  }
 }
 
 1;

--- a/t/basic.t
+++ b/t/basic.t
@@ -19,6 +19,9 @@ subtest "status_code == 31488" => sub {
   );
 
   is($status->as_string, "exited 123", "->as_string is as expected");
+
+  eval { $status->assert_ok("test") };
+  like($@, qr{^test exited 123}, '->assert_ok throws string error');
 };
 
 subtest "status_code == 395" => sub {
@@ -39,6 +42,9 @@ subtest "status_code == 395" => sub {
     "exited 1, caught SIGSEGV; dumped core",
     "->as_string is as expected",
   );
+
+  eval { $status->assert_ok("test") };
+  like($@, qr{^test exited 1}, '->assert_ok throws string error');
 };
 
 subtest "status_code == -1" => sub {
@@ -60,11 +66,11 @@ subtest "status_code == -1" => sub {
     "->as_struct is as expected",
   );
 
-  is(
-    $status->as_string,
-    qq{did not run; \$? was -1, \$! was "$str" (errno $num)},
-    "->as_string is as expected",
-  );
+  my $expect_err = qq{did not run; \$? was -1, \$! was "$str" (errno $num)};
+  is($status->as_string, $expect_err, "->as_string is as expected");
+
+  eval { $status->assert_ok("test") };
+  like($@, qr{^test \Q$expect_err\E}, '->assert_ok throws string error');
 };
 
 done_testing;


### PR DESCRIPTION
If we get a negative status, we bless an arrayref into
'Process::Status::Negative'. Then, in ->assert_ok, we'd call $$self,
which would, clearly, fail. This commit fixes that, and also adds tests
for ->assert_ok.